### PR TITLE
Fix: Pie-Chart 'other' slice aggregation and percentage rounding

### DIFF
--- a/src/lib/PieChart.svelte
+++ b/src/lib/PieChart.svelte
@@ -7,25 +7,26 @@
 	data = data.sort(([n1, v1], [n2, v2]) => v2 - v1);
 
 	function getPercentage(val: number) {
-		let degrees = val * (180 / Math.PI);
-		return Math.floor((degrees / 360) * 100);
-	}
+        return Math.round((val / (2 * Math.PI)) * 100);
+    }
 
-	const sliceCount = data.length < 9 ? data.length : 9;
+	const maxSlices = 9;
+    const sliceCount = Math.min(data.length, maxSlices);
 
-	for (let i = 0; i < sliceCount; i++) {
-		if (i == 4) {
-			let value = data.slice(9).reduce((acc, [_, v]) => {
-				if (v <= 0) return acc;
-				return acc + v;
-			}, 0);
-			_data[i] = { name: 'other', value };
-			continue;
-		}
+    for (let i = 0; i < sliceCount; i++) {
+        if (i === maxSlices - 1 && data.length > maxSlices) {
+            // Last slice aggregates all remaining items into "other"
+            let value = data.slice(maxSlices - 1).reduce((acc, [_, v]) => {
+                if (v <= 0) return acc;
+                return acc + v;
+            }, 0);
+            _data[i] = { name: 'other', value };
+            continue;
+        }
 
-		let [name, value] = data[i];
-		_data[i] = { name, value };
-	}
+        let [name, value] = data[i];
+        _data[i] = { name, value };
+    }
 
 	const width = 224;
 	const height = 224;


### PR DESCRIPTION
Fix Pie-Chart 'other' slice aggregation and percentage rounding. 

The 'other' slice was hardcoded at index 4 in a loop of up to 9 slices, which caused two problems: data[4] was silently dropped (the 5th-largest subreddit never appeared on the chart), and 'other' only summed data[9] onwards instead of everything beyond the displayed slices. Items at indices 5-8 were shown individually even though they should have been part of the catch-all. 

Changed it so 'other' is the last slice (index 8) and aggregates everything from index 8 onwards, and only appears when there are actually more items than fit. 

I tested on chronically online users like GallowBoob: 'other' now correctly represents ~49% of activity instead of being undersized. Also changed getPercentage from Math.floor to Math.round. Floor always rounded down, so small slices that were 0.6% all displayed as 0% and totals fell well short of 100. With round, totals come out to 99-101% which is normal rounding drift.